### PR TITLE
Fix #600 store form textarea values in a text column in sql

### DIFF
--- a/backup/moodle2/backup_competvet_stepslib.php
+++ b/backup/moodle2/backup_competvet_stepslib.php
@@ -131,7 +131,7 @@ class backup_competvet_activity_structure_step extends backup_activity_structure
         $casedatas = new backup_nested_element('casedatas');
         $casedata = new backup_nested_element('casedata', ['id'], [
             'fieldid', 'entryid', 'intvalue', 'decvalue', 'shortcharvalue',
-            'charvalue', 'value', 'valueformat', 'usermodified', 'timecreated', 'timemodified',
+            'charvalue', 'textvalue', 'value', 'valueformat', 'usermodified', 'timecreated', 'timemodified',
         ]);
 
         $formdatas = new backup_nested_element('formdatas');

--- a/classes/local/persistent/case_data.php
+++ b/classes/local/persistent/case_data.php
@@ -37,7 +37,7 @@ class case_data extends persistent {
     const FIELD_TYPE_TO_INTERNAL = [
         'text' => 'charvalue',
         'date' => 'intvalue',
-        'textarea' => 'charvalue',
+        'textarea' => 'textvalue',
         'select' => 'intvalue',
     ];
     /**
@@ -88,6 +88,12 @@ class case_data extends persistent {
                 'type' => PARAM_TEXT,
                 'default' => '',
                 'message' => new lang_string('invaliddata', 'competvet', 'charvalue'),
+            ],
+            'textvalue' => [
+                'null' => NULL_ALLOWED,
+                'type' => PARAM_TEXT,
+                'default' => '',
+                'message' => new lang_string('invaliddata', 'competvet', 'textvalue'),
             ],
         ];
     }

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/competvet/db" VERSION="20240917" COMMENT="XMLDB file for Moodle mod_competvet"
+<XMLDB PATH="mod/competvet/db" VERSION="20250224" COMMENT="XMLDB file for Moodle mod_competvet"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -376,6 +376,7 @@
         <FIELD NAME="decvalue" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5"/>
         <FIELD NAME="shortcharvalue" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="charvalue" TYPE="char" LENGTH="1333" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="textvalue" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -279,5 +279,29 @@ function xmldb_competvet_upgrade($oldversion) {
         }
         upgrade_mod_savepoint(true, 2025021001, 'competvet');
     }
+
+    if ($oldversion < 2025021004) {
+
+        // Define field textvalue to be added to competvet_case_data.
+        $table = new xmldb_table('competvet_case_data');
+        $field = new xmldb_field('textvalue', XMLDB_TYPE_TEXT, null, null, null, null, null, 'charvalue');
+
+        // Conditionally launch add field textvalue.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Intentionally leaving charvalue as it is for safety.
+        $fields = $DB->get_records('competvet_case_field', ['type' => 'textarea']);
+        foreach ($fields as $field) {
+            $DB->execute(
+                "UPDATE {competvet_case_data} SET textvalue = charvalue WHERE fieldid = :fieldid",
+                ['fieldid' => $field->id]
+            );
+        }
+        // Competvet savepoint reached.
+        upgrade_mod_savepoint(true, 2025021004, 'competvet');
+    }
+
     return true;
 }


### PR DESCRIPTION
There seemed to be a character limit in the case form textarea files. This fix stores the data from these field in a new column. Any existing data in the charvalue fields linked to a textarea field will have data migrated to this new column too.